### PR TITLE
Profile page implementation (for home tab)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,10 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+
     implementation libs.appcompat
     implementation libs.material
     implementation libs.activity

--- a/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
@@ -19,6 +19,7 @@ import com.firebase.ui.auth.IdpResponse;
 import com.firebase.ui.auth.data.model.FirebaseAuthUIAuthenticationResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.northcoders.media_tracker_front.viewmodel.LoginActivityViewModel;
 
 import java.util.Arrays;
 import java.util.List;

--- a/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
@@ -82,7 +82,8 @@ public class LoginActivity extends AppCompatActivity {
             Log.i("Firebase Login Page","User is already logged in: " + currentUser.getEmail());
             // Now we can start a new intent to move to the MainActivity
             Intent intent = new Intent(this, com.northcoders.media_tracker_front.MainActivity.class);
-
+            // make sure the user is on the backend
+            viewModel.getAuth();
             // This actually starts the move to the MainActivity
             startActivity(intent);
             finish();

--- a/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/LoginActivity.java
@@ -84,6 +84,7 @@ public class LoginActivity extends AppCompatActivity {
 
             // This actually starts the move to the MainActivity
             startActivity(intent);
+            finish();
         }
         else{
             Log.i("Firebase Login Page","User is not signed in");
@@ -116,6 +117,7 @@ public class LoginActivity extends AppCompatActivity {
 
             // This actually starts the move to the MainActivity
             startActivity(intent);
+            finish();
 
         } else {
             Log.e("FIREBASE LOGIN L_ACTIVITY",result.toString());

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
@@ -69,6 +69,7 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
                                 android.R.anim.slide_in_left,
                                 android.R.anim.slide_out_right)
                         .replace(R.id.frameLayoutFragment, profileFragment)
+                        .addToBackStack("profileFragmentTransaction") // allow user to press back to go back to home fragment
                         .commit();
             }
         });

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
@@ -17,6 +17,8 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 import android.widget.ImageButton;
 
+import com.bumptech.glide.Glide;
+import com.google.firebase.auth.FirebaseAuth;
 import com.northcoders.media_tracker_front.R;
 import com.northcoders.media_tracker_front.adapter.RecyclerViewInterface;
 import com.northcoders.media_tracker_front.adapter.ShowSearchResultAdapter;
@@ -48,7 +50,12 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ImageButton profilePicture = binding.profilepicturemain ;
-
+        Glide.with(profilePicture)
+                .load(FirebaseAuth.getInstance().getCurrentUser().getPhotoUrl().toString())
+                .circleCrop()
+//                .apply(RequestOptions.circleCropTransform())
+                .error(R.drawable.circularcustombutton)
+                .into(profilePicture);
 
 
         profilePicture.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
+import android.widget.ImageButton;
 
 import com.northcoders.media_tracker_front.R;
 import com.northcoders.media_tracker_front.adapter.RecyclerViewInterface;
@@ -31,6 +32,7 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
     ArrayList<ShowSearchResult> showSearchResultArrayList;
     ShowSearchResultAdapter showSearchResultAdapter;
     ShowSearchResultViewModel viewModel;
+    private ProfileFragment profileFragment = new ProfileFragment();
 
     public HomeFragment() {
         // Required empty public constructor
@@ -43,8 +45,23 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState){
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ImageButton profilePicture = binding.profilepicturemain ;
+
+
+
+        profilePicture.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                getActivity().getSupportFragmentManager()
+                        .beginTransaction()
+                        .replace(R.id.frameLayoutFragment, profileFragment)
+                        .commit();
+            }
+        });
+
+
         // Initialize SearchView
         SearchView searchView = view.findViewById(R.id.SearchViewHome);
         searchView.clearFocus();
@@ -55,7 +72,7 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
         mButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                // Handle button click
+                //Handle button click
                 Toast.makeText(getContext(), "Button clicked!", Toast.LENGTH_SHORT).show();
                 Fragment searchFragment = new ShowSearchFragment();
                 getActivity().getSupportFragmentManager().beginTransaction()
@@ -64,71 +81,16 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
                         .commit();
             }
         });
-
-
-        /*
-        // implement click event
-        searchView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view)
-            {
-                // Operations Performed On Clicking the Button
-                // Are Done Here
-                Log.i("hello", "button was clicked");
-
-            }
-            });
-        /*
-        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-            @Override
-            public boolean onQueryTextSubmit(String query) {
-                //getShowSearchResult(query);
-                Log.i("GET request", query);
-                Log.i("GET request", "I am here");
-                getShowSearchResult(query);
-                return true;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String newText) {
-                Log.i("GET request", newText);
-                return false;
-            }
-        });
-         */
     }
+
+
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_home, container, false);
-        // Inflate the layout for this fragment
-        View view = inflater.inflate(R.layout.fragment_home, container, false);
-        return binding.getRoot();  // needed to see the recyclerview
-        //return view;                 // needed for search field
+        return binding.getRoot();
     }
 
-    /*
-    private  void getShowSearchResult(String query) {
-        viewModel.getShowSearchResult(query).observe(this, new Observer<List<ShowSearchResult>>() {
-            @Override
-            public void onChanged(List<ShowSearchResult> showSearchResultList) {
-                showSearchResultArrayList = (ArrayList<ShowSearchResult>) showSearchResultList;
-                displayShowSearchResultInRecyclerView();
-            }
-        });
-    }
-    */
-
-    /*
-    private void displayShowSearchResultInRecyclerView() {
-        recyclerView = binding.recyclerview;
-        showSearchResultAdapter = new ShowSearchResultAdapter(showSearchResultArrayList, this.getContext(), this);
-        recyclerView.setAdapter(showSearchResultAdapter);
-        recyclerView.setLayoutManager(new LinearLayoutManager(this.getContext()));
-        recyclerView.setHasFixedSize(true);
-        showSearchResultAdapter.notifyDataSetChanged();
-    }
-*/
     @Override
     public void onItemClick(int position) {
     }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/HomeFragment.java
@@ -63,6 +63,11 @@ public class HomeFragment extends Fragment implements RecyclerViewInterface  {
             public void onClick(View v) {
                 getActivity().getSupportFragmentManager()
                         .beginTransaction()
+                        .setCustomAnimations(
+                                android.R.anim.fade_in,
+                                android.R.anim.fade_out,
+                                android.R.anim.slide_in_left,
+                                android.R.anim.slide_out_right)
                         .replace(R.id.frameLayoutFragment, profileFragment)
                         .commit();
             }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -73,6 +73,7 @@ public class ProfileFragment extends Fragment {
                                 getActivity().startActivity(intent);
                                 // finishing the activity prevents the back button opening the app again
                                 getActivity().finish();
+                                Toast.makeText(getContext(), "Log out successful", Toast.LENGTH_SHORT).show();
                             }
                         });
             }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -43,6 +43,7 @@ public class ProfileFragment extends Fragment {
         loadProfilePicture();
         loadLogoutButton();
         loadDeleteButton();
+        binding.profileFragmentUsername.setText(FirebaseAuth.getInstance().getCurrentUser().getDisplayName());
 
 
     }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.firebase.ui.auth.AuthUI;
@@ -31,35 +32,8 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-        // Load in the user's profile picture from the google account
-        // As a circular image
-        ShapeableImageView profilePicture = binding.profileFragmentAvatar;
-        Glide.with(profilePicture)
-                .load(FirebaseAuth.getInstance().getCurrentUser().getPhotoUrl().toString())
-                .circleCrop()
-                .error(R.drawable.circularcustombutton)
-                .into(profilePicture);
-
-        // Logic for log out button
-        binding.profileFragmentLogoutButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                AuthUI.getInstance()
-                        .signOut(getContext())
-                        .addOnCompleteListener(new OnCompleteListener<Void>() {
-                            // On complete-> Place the app in the login page
-                            @Override
-                            public void onComplete(@NonNull Task<Void> task) {
-                                Intent intent = new Intent(getContext(),com.northcoders.media_tracker_front.LoginActivity.class);
-                                getActivity().startActivity(intent);
-                                // finishing the activity prevents the back button opening the app again
-                                getActivity().finish();
-                            }
-                        });
-
-            }
-        });
+        loadProfilePicture();
+        loadLogoutButton();
 
 
 
@@ -71,4 +45,41 @@ public class ProfileFragment extends Fragment {
         binding = DataBindingUtil.inflate(inflater,R.layout.fragment_profile,container,false);
         return binding.getRoot();
     }
+
+    private void loadProfilePicture(){
+        // Load in the user's profile picture from the google account
+        // As a circular image
+        ShapeableImageView profilePicture = binding.profileFragmentAvatar;
+        Glide.with(profilePicture)
+                .load(FirebaseAuth.getInstance().getCurrentUser().getPhotoUrl().toString())
+                .circleCrop()
+                .error(R.drawable.circularcustombutton)
+                .into(profilePicture);
+
+    }
+
+    private void loadLogoutButton(){
+        // Logic for log out button
+        binding.profileFragmentLogoutButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                 AuthUI.getInstance()
+                        .signOut(getContext())
+                        .addOnCompleteListener(new OnCompleteListener<Void>() {
+                            // On complete-> Place the app in the login page
+                            @Override
+                            public void onComplete(@NonNull Task<Void> task) {
+                                Intent intent = new Intent(getContext(),com.northcoders.media_tracker_front.LoginActivity.class);
+                                getActivity().startActivity(intent);
+                                // finishing the activity prevents the back button opening the app again
+                                getActivity().finish();
+                            }
+                        });
+            }
+        });
+
+    }
+
+
+
 }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -1,13 +1,16 @@
 package com.northcoders.media_tracker_front.fragments;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,8 +22,10 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.material.imageview.ShapeableImageView;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.northcoders.media_tracker_front.R;
 import com.northcoders.media_tracker_front.databinding.FragmentProfileBinding;
+import com.northcoders.media_tracker_front.viewmodel.ProfileViewModel;
 
 public class ProfileFragment extends Fragment {
     private FragmentProfileBinding binding;
@@ -32,9 +37,12 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        // These should be in a clickHandler class
+        // No time at this point
         loadProfilePicture();
         loadLogoutButton();
-
+        loadDeleteButton();
 
 
     }
@@ -80,6 +88,71 @@ public class ProfileFragment extends Fragment {
         });
 
     }
+
+    private void loadDeleteButton() {
+        ProfileViewModel profileViewModel = new ProfileViewModel(this.requireActivity().getApplication());
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+    binding.profileFragmentDeleteButton.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            AlertDialog.Builder quit = new AlertDialog.Builder(getContext())
+                    .setTitle("Delete Account")
+                    .setMessage("Are you sure you want to delete your account " +user.getDisplayName() +"\"?")
+                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            Log.i("Profile Fragment","USER PRESSED YES");
+                            profileViewModel.deleteUser();
+                            // For now the user will just be locally signed out
+                            // Their data on the backend will be deleted but not their firebase account
+                            // When they log in again another user entry will be made on the backend
+                            FirebaseAuth.getInstance().signOut();
+                            //deleteUserFirebase();
+                            Toast.makeText(getContext(), "You have successfully deleted your account", Toast.LENGTH_SHORT).show();
+                            Intent intent = new Intent(getContext(),com.northcoders.media_tracker_front.LoginActivity.class);
+                            getActivity().startActivity(intent);
+                            // finishing the activity prevents the back button opening the app again
+                            getActivity().finish();
+                        }
+                    })
+                    .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.cancel();
+                        }
+                    });
+            quit.show();
+        }
+
+    });
+    }
+
+
+    /**
+     * This is the method to delete the user from Firebase
+     * Will be done in the future but can't be done at this time
+     * For now the user will be deleted off the backend database
+     */
+
+   /* private void deleteUserFirebase(){
+
+        FirebaseAuth.getInstance().getCurrentUser().delete().addOnSuccessListener(
+                new OnSuccessListener<Void>() {
+                    @Override
+                    public void onSuccess(Void unused) {
+                        Log.d("ProfileFragment", "User account deleted.");
+
+                        Toast.makeText(getContext(), "You have successfully deleted your account", Toast.LENGTH_SHORT).show();
+                        Intent intent = new Intent(getContext(),com.northcoders.media_tracker_front.LoginActivity.class);
+                        getActivity().startActivity(intent);
+                        // finishing the activity prevents the back button opening the app again
+                        getActivity().finish();
+
+                    }
+                }
+        );
+
+    }*/
 
 
 

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -1,7 +1,9 @@
 package com.northcoders.media_tracker_front.fragments;
 
+import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
@@ -11,6 +13,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.bumptech.glide.Glide;
+import com.firebase.ui.auth.AuthUI;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 import com.google.android.material.imageview.ShapeableImageView;
 import com.google.firebase.auth.FirebaseAuth;
 import com.northcoders.media_tracker_front.R;
@@ -35,6 +40,29 @@ public class ProfileFragment extends Fragment {
                 .circleCrop()
                 .error(R.drawable.circularcustombutton)
                 .into(profilePicture);
+
+        // Logic for log out button
+        binding.profileFragmentLogoutButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                AuthUI.getInstance()
+                        .signOut(getContext())
+                        .addOnCompleteListener(new OnCompleteListener<Void>() {
+                            // On complete-> Place the app in the login page
+                            @Override
+                            public void onComplete(@NonNull Task<Void> task) {
+                                Intent intent = new Intent(getContext(),com.northcoders.media_tracker_front.LoginActivity.class);
+                                getActivity().startActivity(intent);
+                                // finishing the activity prevents the back button opening the app again
+                                getActivity().finish();
+                            }
+                        });
+
+            }
+        });
+
+
+
     }
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -2,6 +2,8 @@ package com.northcoders.media_tracker_front.fragments;
 
 import android.os.Bundle;
 
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 
 import android.view.LayoutInflater;
@@ -9,8 +11,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.northcoders.media_tracker_front.R;
+import com.northcoders.media_tracker_front.databinding.FragmentProfileBinding;
 
 public class ProfileFragment extends Fragment {
+    private FragmentProfileBinding binding;
 
     public ProfileFragment() {
         // Required empty public constructor
@@ -20,6 +24,7 @@ public class ProfileFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_profile, container, false);
+        binding = DataBindingUtil.inflate(inflater,R.layout.fragment_profile,container,false);
+        return binding.getRoot();
     }
 }

--- a/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/fragments/ProfileFragment.java
@@ -10,6 +10,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.bumptech.glide.Glide;
+import com.google.android.material.imageview.ShapeableImageView;
+import com.google.firebase.auth.FirebaseAuth;
 import com.northcoders.media_tracker_front.R;
 import com.northcoders.media_tracker_front.databinding.FragmentProfileBinding;
 
@@ -20,6 +23,19 @@ public class ProfileFragment extends Fragment {
         // Required empty public constructor
     }
 
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        // Load in the user's profile picture from the google account
+        // As a circular image
+        ShapeableImageView profilePicture = binding.profileFragmentAvatar;
+        Glide.with(profilePicture)
+                .load(FirebaseAuth.getInstance().getCurrentUser().getPhotoUrl().toString())
+                .circleCrop()
+                .error(R.drawable.circularcustombutton)
+                .into(profilePicture);
+    }
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {

--- a/app/src/main/java/com/northcoders/media_tracker_front/model/AppUserRepository.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/model/AppUserRepository.java
@@ -15,6 +15,7 @@ import retrofit2.Response;
 
 public class AppUserRepository {
     private MutableLiveData<AppUser> currentUser= new MutableLiveData<AppUser>();
+    private boolean status;
 
     private Application application;
 
@@ -42,5 +43,33 @@ public class AppUserRepository {
             }
         });
     }
+
+    public boolean deleteUser(){
+        UserActionsService userActionsService = RetrofitInstance.getUserService();
+
+        Call<Void> deleteUserCall = userActionsService.deleteUser();
+        deleteUserCall.enqueue(new Callback<Void>() {
+            @Override
+            public void onResponse(Call<Void> call, Response<Void> response) {
+                if(response.code() == 200){
+                    Log.i("DeleteUser Response From Back", String.valueOf(response.code()));
+                    status = true;
+                }
+                else{
+                    status = false;
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Void> call, Throwable t) {
+                Log.e("DeleteUser Response From Back",call.toString());
+                Log.e("DeleteUser Response From Back","WE FAILED: " + t.getMessage());
+            }
+        });
+
+        return status;
+    }
+
+
 
 }

--- a/app/src/main/java/com/northcoders/media_tracker_front/service/UserActionsService.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/service/UserActionsService.java
@@ -1,10 +1,13 @@
 package com.northcoders.media_tracker_front.service;
 
 import retrofit2.Call;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 public interface UserActionsService {
 
-
     @GET("users/auth")
     Call<Void> auth();
+
+    @DELETE("users")
+    Call<Void> deleteUser();
 }

--- a/app/src/main/java/com/northcoders/media_tracker_front/viewmodel/LoginActivityViewModel.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/viewmodel/LoginActivityViewModel.java
@@ -1,4 +1,4 @@
-package com.northcoders.media_tracker_front;
+package com.northcoders.media_tracker_front.viewmodel;
 
 import android.app.Application;
 

--- a/app/src/main/java/com/northcoders/media_tracker_front/viewmodel/ProfileViewModel.java
+++ b/app/src/main/java/com/northcoders/media_tracker_front/viewmodel/ProfileViewModel.java
@@ -1,0 +1,21 @@
+package com.northcoders.media_tracker_front.viewmodel;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+
+import com.northcoders.media_tracker_front.model.AppUserRepository;
+
+public class ProfileViewModel extends AndroidViewModel {
+
+    private AppUserRepository appUserRepository;
+
+    public ProfileViewModel(@NonNull Application application) {
+        super(application); this.appUserRepository = new AppUserRepository(application);
+    }
+
+    public boolean deleteUser(){
+       return appUserRepository.deleteUser();
+    }
+}

--- a/app/src/main/res/drawable/circularcustombutton.xml
+++ b/app/src/main/res/drawable/circularcustombutton.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+
+    <solid android:color="@color/white"/>
+    <corners android:radius="500dp"/>
+    <size android:width="100dp"
+        android:height="100dp"/>
+
+</shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -34,7 +34,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintHorizontal_bias="1"
-            android:scaleType="centerCrop"
             android:background="@drawable/circularcustombutton"
             />
         <!-- Add a SearchView widget -->

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -21,22 +21,22 @@
             android:layout_height="wrap_content"
             android:text="Welcome to...."
             android:textSize="30sp"
-            app:layout_constraintEnd_toStartOf="@+id/ProfilePicImage"
+            app:layout_constraintEnd_toStartOf="@+id/profilepicturemain"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/ProfilePicImage"
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/profilepicturemain"
             android:layout_width="102dp"
             android:layout_height="111dp"
             android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
-            android:src="@drawable/ic_launcher_foreground"
+            app:layout_constraintStart_toStartOf="@+id/HomeTitle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:shapeAppearance="@style/roundedImageView"
-            tools:src="@tools:sample/avatars" />
-
+            app:layout_constraintHorizontal_bias="1"
+            android:scaleType="centerCrop"
+            android:background="@drawable/circularcustombutton"
+            />
         <!-- Add a SearchView widget -->
         <!--
         <androidx.appcompat.widget.SearchView
@@ -77,7 +77,7 @@
             android:queryHint="Search TV Show or Movie..."
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"></SearchView>
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <Button
             android:id="@+id/button_searchShow"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<layout>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -68,3 +69,4 @@
     </LinearLayout>
 
 </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -44,13 +44,6 @@
                  />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/profile_fragment_edit_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/edit_username" />
-
-            <com.google.android.material.button.MaterialButton
                 android:id="@+id/profile_fragment_logout_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+<FrameLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingHorizontal="24dp"


### PR DESCRIPTION
- Home fragment has a clickable profile picture in the corner
- Animated transition between home fragment and profile fragment
- User can press phone back button to go back to home fragment
- Glide used to display the profile picture (displayed circular)
- Profile fragment displays user's profile picture and user's google account name
- User has ability to log out and is sent back to the login page (they're unable to come back into the app via the back button)
- User has the ability to delete themselves from backend database (Firebase deletion to be implemented soon), brings the user back to the login page (also unable to go back with back button)
- Change username button removed 
- Toast's added for user log out and user account deletions 